### PR TITLE
Settlement resources closes #53

### DIFF
--- a/cos/models/Board.py
+++ b/cos/models/Board.py
@@ -1,12 +1,107 @@
+import random
+
 from Settement import Settlement
+from Tile import Token
+from Tile import WaterTile
+from Tile import TerrainTile
+from Road import Road
 
 class Board(object):
     def __init__(self):
+        self.tiles = {}
         self.open_settlements = {}
+        self.roads = {}
+
+        # BEGIN SETUP FOR HEX TILES:
+        # First the resource types are defined, except desert
+        resource_types = ["brick", "ore", "wool", "lumber", "grain"]
+
+        # Next all possible token digits are defined
+        token_numbers = [2, 3, 3, 4, 4, 5, 5, 6, 6, 8, 8, 9, 9, 10, 10, 11, 11, 12]
+
+        # Now Token objects are created with each digit
+        tokens = []
+        for token_number in token_numbers:
+            tokens.append(Token(token_number))
+        resources = []
+
+        # Now an array of the correct number of resources per resource type is created
+        for type in resource_types:
+            if type == "brick" or type == "ore":
+                resources.extend((type, type, type))
+            else:
+                resources.extend((type, type, type, type))
+
+        # Shuffle token list (only token list needs to be shuffled because resources will be shuffled later)
+        random.shuffle(tokens)
+        random.shuffle(resources)
+
+        # Tiles are created with a kind (water or terrain), a now random resource, and now random token
+        terrain_tiles = []
+        water_tiles = []
+
+        for x in range(0, len(tokens)):
+            terrain_tiles.append(TerrainTile(resource=resources[x], token=tokens[x]))
+
+        # the desert terrain with token 7 is added to the list (since this terrain and token are always matched, it
+        # must be left out of the randomization process above and be added later
+        terrain_tiles.append(TerrainTile(resource="desert", token=Token(7)))
+
+        # shuffle the tiles array (this is only needed because we want the desert in a random place as well)
+        random.shuffle(self.tiles)
+
+        # creates 18 water tiles that will surround the terrain board
+        for x in range(0, 18):
+            water_tiles.append(WaterTile())
+
+        # "Places" each tile in a particular "slot" of the game board. There are 7 rows on the game board, and each row
+        # has 4, 5, 6, 7, 6, 5, 4 tiles in each row, respectively. The first and last rows consist only of water tiles,
+        # as well as the first and last tile of each row. All other tiles are set to terrain. Tiles can be identified
+        # by their id: "t1,1" = "tile at row 1, column 1"
+        water_iter = iter(water_tiles)
+        terrain_iter = iter(terrain_tiles)
+        for row in range(0,7):
+            if row == 0 or row == 6:
+                for column in range(1, 5):
+                    tile = water_iter.next()
+                    tile.place_tile(row=row + 1, column=column)
+                    self.tiles[tile.id] = tile
+            if row == 1 or row == 5:
+                for column in range(1, 6):
+                    if column == 1 or column == 5:
+                        tile = water_iter.next()
+                        tile.place_tile(row=row + 1, column=column)
+                        self.tiles[tile.id] = tile
+                    else:
+                        tile = terrain_iter.next()
+                        tile.place_tile(row=row + 1, column=column)
+                        self.tiles[tile.id] = tile
+            if row == 2 or row == 4:
+                for column in range(1, 7):
+                    if column == 1 or column == 6:
+                        tile = water_iter.next()
+                        tile.place_tile(row=row + 1, column=column)
+                        self.tiles[tile.id] = tile
+                    else:
+                        tile = terrain_iter.next()
+                        tile.place_tile(row=row + 1, column=column)
+                        self.tiles[tile.id] = tile
+            if row == 3:
+                for column in range(1, 8):
+                    if column == 1 or column == 7:
+                        tile = water_iter.next()
+                        tile.place_tile(row=row + 1, column=column)
+                        self.tiles[tile.id] = tile
+                    else:
+                        tile = terrain_iter.next()
+                        tile.place_tile(row=row + 1, column=column)
+                        self.tiles[tile.id] = tile
+
+        # BEGIN SETUP FOR SETTLEMENTS:
         # Creates settlement objects and adds them to the open_settlement dict as {settlement_id: Settlement}
         # There are 6 rows of settlements that have 7, 9, 11, 11, 9, and 7 settlements to each row, respectively
         # Each settlement in a row represents a column, and all columns begin at 1, regardless of where it exists on
-        # the actual board.
+        # the actual board. Settlements can be identified by their id: "s1,1" = "settlement at row 1, column 1"
         for row in range(1, 7):
             if (row == 1) or (row == 6):
                 for column in range(1, 8):
@@ -20,3 +115,60 @@ class Board(object):
                 for column in range(1, 12):
                     settlement = Settlement(row=row,column=column)
                     self.open_settlements[settlement.id] = settlement
+
+        # BEGIN SETUP FOR ROADS:
+        # The road grid looks like this: The road rows alternate between running horizontal and running vertical. The
+        # first row is horizontal (running between hex bottoms and tops) and consists of 6 roads. The next row is
+        # vertical (running between hexes vertically) and consists of 4 roads. The process repeats alternating though
+        # each row on the board. Roads can be identified by their id: "r1,1" = "settlement at row 1, column 1"
+        for row in range(0, 11):
+            if row % 2 == 0:
+                alignment = "horizontal"
+                if row == 0 or row == 10:
+                    for column in range(1, 7):
+                        road = Road(row=row + 1, column=column, alignment=alignment)
+                        self.roads[road.id] = road
+                if row == 2 or row == 8:
+                    for column in range(1, 9):
+                        road = Road(row=row + 1, column=column, alignment=alignment)
+                        self.roads[road.id] = road
+                if row == 4 or row == 6:
+                    for column in range(1, 11):
+                        road = Road(row=row + 1, column=column, alignment=alignment)
+                        self.roads[road.id] = road
+            else:
+                alignment = "vertical"
+                if row == 1 or row == 9:
+                    for column in range(1, 5):
+                        road = Road(row=row + 1, column=column, alignment=alignment)
+                        self.roads[road.id] = road
+                if row == 3 or row == 7:
+                    for column in range(1, 6):
+                        road = Road(row=row + 1, column=column, alignment=alignment)
+                        self.roads[road.id] = road
+                if row == 5:
+                    for column in range(1, 6):
+                        road = Road(row=row + 1, column=column, alignment=alignment)
+                        self.roads[road.id] = road
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        board_dict = {}
+
+        tiles = []
+        for key, val in self.tiles.iteritems():
+            tiles.append({key: val.get_dict()})
+        board_dict["Tiles"] = tiles
+
+        settlements = []
+        for key, val in self.open_settlements.iteritems():
+            settlements.append({key: val.get_dict()})
+        board_dict["Settlements"] = settlements
+
+        roads = []
+        for key, val in self.roads.iteritems():
+            roads.append({key: val.get_dict()})
+        board_dict["Roads"] = roads
+
+        return board_dict
+

--- a/cos/models/Game.py
+++ b/cos/models/Game.py
@@ -101,7 +101,7 @@ class Game(object):
         """
         buying_player = self.players[player_id]
         buying_settlement = self.game_board.open_settlements.pop(settlement_id)
-        buying_player.add_settlement(buying_settlement)
+        buying_player.add_settlement(buying_settlement, self.game_board)
 
     def roll_dice(self, player_id):
         """

--- a/cos/models/Player.py
+++ b/cos/models/Player.py
@@ -1,21 +1,21 @@
 import random
-
+from Tile import TerrainTile
 
 class Player(object):
     """ Class for defining a Player Object 
 
-            Current Attributes
-            ------------------
-            id: String
-            name: String
-            color: String
-            settlements: {settlement_id: Settlement}
+        Current Attributes
+        ------------------
+        id: String
+        name: String
+        color: String
+        settlements: {settlement_id: Settlement}
 
-            Methods
-            -------
-            add_settlement(Settlement)
+        Methods
+        -------
+        add_settlement(Settlement)
 
-        """
+    """
     def __init__(self, name, color, age):
         id_string = ''.join(random.choice('0123456789ABCDEFGHIJKLMNZQRSTUVWXYZ') for i in range(6))
         self.id = id_string
@@ -25,23 +25,38 @@ class Player(object):
         self.age = age
         self.current_roll = 0
 
-    def add_settlement(self, settlement):
+        self.resources_by_roll = {}
+        for num in range(1,13):
+            self.resources_by_roll[num] = None
+
+    def add_settlement(self, settlement, game_board):
         """
-                    Adds a settlement to the Player's list of settlments dictonary 
+            Adds a settlement to the Player's list of settlments dictonary 
 
-                    Parameters
-                    ----------
-                    settlement : Settlement
-                        settlement to be added to settelements list
+            Parameters
+            ----------
+            settlement : Settlement
+                settlement to be added to settlements list
+            game_board : Board
 
-                    Returns
-                    -------
-                    None
+            Returns
+            -------
+            None
 
-                """
+        """
         # type: (Settlement) -> None
         settlement.ownedBy = self
         settlement.color = self.color
         self.settlements[settlement.id] = settlement
+        nearby_tiles = settlement.nearby_tiles
+        for tile_id in nearby_tiles:
+            tile = game_board.tiles[tile_id]
+            if isinstance(tile, TerrainTile):
+                token_digit = tile.token.digit
+                tile_resource = tile.resource
+                if self.resources_by_roll[token_digit] is not None:
+                    self.resources_by_roll[token_digit].append(tile_resource)
+                else:
+                    self.resources_by_roll[token_digit] = [tile_resource]
 
 

--- a/cos/models/Road.py
+++ b/cos/models/Road.py
@@ -1,0 +1,37 @@
+class Road(object):
+    """ Class for defining a Road Object 
+
+            Current Attributes
+            ------------------
+            id: String (in the form of "r(row),(column)" example: "r1,5"
+            location: Tuple (row, column)
+            color: String
+            ownedBy: Player
+            attached_settlement: Settlement
+            alignment: String (vertical or horizontal)
+
+            Methods
+            -------
+            get_dict()
+
+    """
+    def __init__(self, row, column, alignment):
+        self.location = (row, column)
+        self.id = "r" + str(row) + "," + str(column)
+        self.color = 'grey'
+        self.ownedBy = None
+        self.attached_settlement = None
+        self.alignment = alignment
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        settlement_dict = {}
+        settlement_dict["road_id"] = self.id
+        settlement_dict["road_row"] = self.location[0]
+        settlement_dict["road_column"] = self.location[1]
+        settlement_dict["road_color"] = self.color
+        if self.ownedBy is not None:
+            settlement_dict["road_ownedBy"] = self.ownedBy.id
+        if self.attached_settlement is not None:
+            settlement_dict["attached_settlement"] = self.attached_settlement.id
+        return settlement_dict

--- a/cos/models/Settement.py
+++ b/cos/models/Settement.py
@@ -1,17 +1,18 @@
 class Settlement(object):
-    """ Class for defining a Player Object 
+    """ Class for defining a Settlement Object 
 
-                Current Attributes
-                ------------------
-                id: String (in the form of "s(row),(column)" example: "s1,5"
-                location: Tuple (row, column)
-                color: String
-                ownedBy: Player
-                nearby_tiles: [Tuple (row, column)]
+            Current Attributes
+            ------------------
+            id: String (in the form of "s(row),(column)" example: "s1,5"
+            location: Tuple (row, column)
+            color: String
+            ownedBy: Player
+            nearby_tiles: [Tuple (row, column)]
 
-                Methods
-                -------
-                add_settlement(Settlement)
+            Methods
+            -------
+            add_settlement(Settlement)
+            get_dict()
 
     """
     def __init__(self, row, column):
@@ -30,19 +31,34 @@ class Settlement(object):
         self.nearby_tiles = []
         if row < 4:
             if column % 2 != 0:
-                self.nearby_tiles.append((row, int((column / 2.0) + 0.5)))  # 0.5 is added here to round up, as python's rounding function is stupid
-                self.nearby_tiles.append((row + 1, int((column / 2.0) + 0.5)))
-                self.nearby_tiles.append((row + 1, int((column / 2.0) + 0.5) + 1))
+                self.nearby_tiles.append(self.convert_to_id(row, int((column / 2.0) + 0.5)))  # 0.5 is added here to round up, as python's rounding function is stupid
+                self.nearby_tiles.append(self.convert_to_id(row + 1, int((column / 2.0) + 0.5)))
+                self.nearby_tiles.append(self.convert_to_id(row + 1, int((column / 2.0) + 0.5) + 1))
             else:
-                self.nearby_tiles.append((row, column / 2))
-                self.nearby_tiles.append((row, (column / 2) + 1))
-                self.nearby_tiles.append((row + 1, (column / 2) + 1))
+                self.nearby_tiles.append(self.convert_to_id(row, column / 2))
+                self.nearby_tiles.append(self.convert_to_id(row, (column / 2) + 1))
+                self.nearby_tiles.append(self.convert_to_id(row + 1, (column / 2) + 1))
         else:
             if column % 2 != 0:
-                self.nearby_tiles.append((row, int((column / 2.0) + 0.5)))
-                self.nearby_tiles.append((row, int((column / 2.0) + 0.5) + 1))
-                self.nearby_tiles.append((row + 1, int((column / 2.0) + 0.5)))
+                self.nearby_tiles.append(self.convert_to_id(row, int((column / 2.0) + 0.5)))
+                self.nearby_tiles.append(self.convert_to_id(row, int((column / 2.0) + 0.5) + 1))
+                self.nearby_tiles.append(self.convert_to_id(row + 1, int((column / 2.0) + 0.5)))
             else:
-                self.nearby_tiles.append((row, (column / 2) + 1))
-                self.nearby_tiles.append((row + 1, (column / 2)))
-                self.nearby_tiles.append((row + 1, (column / 2) + 1))
+                self.nearby_tiles.append(self.convert_to_id(row, (column / 2) + 1))
+                self.nearby_tiles.append(self.convert_to_id(row + 1, (column / 2)))
+                self.nearby_tiles.append(self.convert_to_id(row + 1, (column / 2) + 1))
+
+    def convert_to_id(self, row, column):
+        return "t%s,%s" % (row, column)
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        dict = {}
+        dict["settlement_id"] = self.id
+        dict["settlement_row"] = self.location[0]
+        dict["settlement_column"] = self.location[1]
+        dict["settlement_color"] = self.color
+        if self.ownedBy is not None:
+            dict["settlement_ownedBy"] = self.ownedBy.id
+        dict["nearby_tiles"] = self.nearby_tiles
+        return dict

--- a/cos/models/Tile.py
+++ b/cos/models/Tile.py
@@ -1,0 +1,130 @@
+class Tile(object):
+    """ Class for defining a Tile Object 
+
+            Current Attributes
+            ------------------
+            id: String (in the form of "r(row),(column)" example: "r1,5"
+            location: Tuple (row, column)
+
+            Methods
+            -------
+            place_tile(int, int)
+            get_dict()
+
+    """
+    def __init__(self):
+        self.location = (None, None)
+        self.id = None
+
+    def place_tile(self, row, column):
+        """ Sets location to a Tuple of (row, column) and defines id """
+        self.location = (row, column)
+        self.id = 't' + str(row) + ',' + str(column)
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        tile_dict = {}
+        tile_dict["tile_id"] = self.id
+        tile_dict["tile_row"] = self.location[0]
+        tile_dict["tile_column"] = self.location[1]
+
+        return tile_dict
+
+
+class TerrainTile(Tile):
+    """ Class for defining a TerrainTile Object, inherits from Tile
+
+            Current Attributes
+            ------------------
+            (Inherited) id: String (in the form of "r(row),(column)" example: "r1,5"
+            (Inherited) location: Tuple (row, column)
+            token: Token
+            resource: Resource
+
+            Methods
+            -------
+            (Inherited) place_tile(int, int)
+            (Inherited) get_dict()
+
+    """
+    def __init__(self, resource, token):
+        super(TerrainTile, self).__init__()
+        self.resource = resource
+        self.token = token
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        tile_dict = super(TerrainTile, self).get_dict()
+        tile_dict["tile_resource"] = self.resource
+        tile_dict["tile_type"] = "terrain"
+        tile_dict["tile_token"] = self.token.get_dict()
+        return tile_dict
+
+
+class WaterTile(Tile):
+    """ Class for defining a TerrainTile Object, inherits from Tile
+
+            Current Attributes
+            ------------------
+            (Inherited) id: String (in the form of "r(row),(column)" example: "r1,5"
+            (Inherited) location: Tuple (row, column)
+
+            Methods
+            -------
+            (Inherited) place_tile(int, int)
+            (Inherited) get_dict()
+
+    """
+    def __init__(self):
+        super(WaterTile, self).__init__()
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        tile_dict = super(WaterTile, self).get_dict()
+        tile_dict["tile_type"] = "water"
+        return tile_dict
+
+
+class Token(object):
+    """ Class for defining a Tile Object 
+
+            Current Attributes
+            ------------------
+            digit: Int
+            color: String
+            pips: Int
+            
+
+            Methods
+            -------
+            place_tile(int, int)
+            get_token_dict()
+
+    """
+    def __init__(self, digit):
+        self.digit = digit
+        self.color = "black"
+        if self.digit == 2 or self.digit == 12:
+            self.pips = 1
+        elif self.digit == 3 or self.digit == 11:
+            self.pips = 2
+        elif self.digit == 4 or self.digit == 10:
+            self.pips = 3
+        elif self.digit == 5 or self.digit == 9:
+            self.pips = 4
+        elif self.digit == 6 or self.digit == 8:
+            self.pips = 5
+            self.color = "red"
+        else:
+            self.pips = 0
+
+    def get_dict(self):
+        """ returns dictionary representation of object that can be used for json """
+        if self.digit == 0:
+            return "None"
+        else:
+            token_dict = {}
+            token_dict["token_digit"] = self.digit
+            token_dict["token_pips"] = self.pips
+            token_dict["token_color"] = self.color
+            return token_dict

--- a/cos/routes.py
+++ b/cos/routes.py
@@ -10,6 +10,6 @@ def includeme(config):
     config.add_route('startGame',           '/api/game/startGame')
     config.add_route('completeTurn',        '/api/game/completeTurn')
     config.add_route('waitForNewPlayers',   '/api/game/waitForNewPlayers')
-
+    config.add_route('getGameBoard',        '/api/game/getGameBoard')
     config.add_route('buySettlement',       '/api/player/buySettlement')
     config.add_route('waitForTurn',         '/api/player/waitForTurn')

--- a/cos/views/views.py
+++ b/cos/views/views.py
@@ -296,7 +296,7 @@ def buy_settlement(request):
     game.buy_settlement(player_id=player_id, settlement_id=settlement_id)
     player = game.players[player_id]
     return_data = {'status': 'success',
-                   'Settlement': player.settlements[settlement_id].get_dict,
+                   'Settlement': player.settlements[settlement_id].get_dict(),
                    'Player':
                        {'player_id':        player.id,
                         'player_name':      player.name,

--- a/cos/views/views.py
+++ b/cos/views/views.py
@@ -242,7 +242,9 @@ def buy_settlement(request):
             Parameters
             ----------
             request: Request
-                - required JSON parameters: "game_id": String, "player_id": String, and "settlement_id": String
+                - required JSON parameters: "game_id": String, 
+                                            "player_id": String,  
+                                            "settlement_id": String
 
             Returns
             -------
@@ -288,6 +290,14 @@ def buy_settlement(request):
         request.response.status = 400
         return {'error': "Requested Player with id '%s' does not exist in this Game." % player_id}
 
+    if game.game_started is False:
+        request.response.status = 400
+        return {'error': "Game has not started. Settlements cannot be purchased before game has started."}
+
+    if game.current_player_id != player_id:
+        request.response.status = 400
+        return {'error': "Requested Player with id '%s' cannot do this action when it is not their turn." % player_id}
+
     if settlement_id not in game.game_board.open_settlements:
         request.response.status = 400
         return {'error': "Requested Settlement with id "
@@ -296,7 +306,7 @@ def buy_settlement(request):
     game.buy_settlement(player_id=player_id, settlement_id=settlement_id)
     player = game.players[player_id]
     return_data = {'status': 'success',
-                   'Settlement': player.settlements[settlement_id].get_dict,
+                   'Settlement': player.settlements[settlement_id].get_dict(),
                    'Player':
                        {'player_id':        player.id,
                         'player_name':      player.name,
@@ -348,6 +358,10 @@ def roll_dice(request):
     if player_id not in game.players:
         request.response.status = 400
         return {'error': "Requested Player with id '%s' does not exist in this Game." % player_id}
+
+    if game.current_player_id != player_id:
+        request.response.status = 400
+        return {'error': "Requested Player with id '%s' cannot do this action when it is not their turn." % player_id}
 
     roll = game.roll_dice(player_id)
 

--- a/cos/views/views.py
+++ b/cos/views/views.py
@@ -295,12 +295,8 @@ def buy_settlement(request):
 
     game.buy_settlement(player_id=player_id, settlement_id=settlement_id)
     player = game.players[player_id]
-    nearby_tiles = str(player.settlements[settlement_id].nearby_tiles).strip('[]')
     return_data = {'status': 'success',
-                   'Settlement':
-                       {'settlement_id':    player.settlements[settlement_id].id,
-                        'nearby_tiles':     nearby_tiles,
-                        'settlement_color': player.settlements[settlement_id].color},
+                   'Settlement': player.settlements[settlement_id].get_dict,
                    'Player':
                        {'player_id':        player.id,
                         'player_name':      player.name,
@@ -537,3 +533,34 @@ def wait_for_new_players(request):
         time.sleep(5)
 
     return get_players_in_game(request)
+
+@view_config(route_name='getGameBoard', renderer='json')
+def get_game_board(request):
+    """ Returns a game board object.
+
+            Parameters
+            ----------
+            request: Request 
+                - required JSON parameters: "game_id": String
+
+            Returns
+            -------
+            Board object (see object for structure)
+    """
+    json_body = request.json_body
+    if 'game_id' in json_body:
+        game_id = json_body['game_id']
+    else:
+        request.response.status = 400
+        return {'error': "'game_id' is a required parameter for this request"}
+
+    if game_id not in request.registry.games.games:
+        request.response.status = 400
+        return {'error': "Requested Game with id '%s' does not exist." % game_id}
+    game = request.registry.games.games[game_id]
+
+    json_return = json.dumps(game.game_board.get_dict())
+    return Response(
+        content_type='json',
+        body=json_return
+    )


### PR DESCRIPTION
There is no api changes here.

Updates to add board model support for player. Now when a player purchases (or currently selects) a settlement via /api/player/buySettlement, the resources for that settlement's nearby tiles are added to a library based on rolls. In a later update, when a roll is done, all we should have to do is call a function to update resources based on roll, making it a fairly trivial task.