### PR TITLE
Added API call for postman sessions

### DIFF
--- a/api_docs.md
+++ b/api_docs.md
@@ -282,6 +282,34 @@
    }
 ```
 </p></details>
+<details> 
+    <summary>setSessionWithGame</summary><p>
+   
+   This should be called when all players are ready to start the game, once game is started players cannot be added
+   
+   - URL: ```/api/game/setSessionWithGame```
+   - **Required Parameters**: ```game_id: String```
+   - Optional Parameters: ```player_id: String```
+   - Returns
+     - Game object:    
+         - ```player_count: Int```     
+         - ```game_is_full: Bool```    
+      - Player object (if player_id is included in request):    
+         - ```player_id: String``` 
+         - ```player_name: String```
+
+   - Example return: 
+```javascript 
+   { "Game":  {
+                  "player_count": "2", 
+                  "game_is_full": "False"
+     "Player":  {
+                  "player_id": "XF093D", 
+                  "player_name": "Player 3",
+                  "player_color": "orange"
+   }}
+```
+</p></details>
 
 ## Player Methods:
 <details> 

--- a/cos/routes.py
+++ b/cos/routes.py
@@ -9,6 +9,7 @@ def includeme(config):
     config.add_route('startGame',           '/api/game/startGame')
     config.add_route('waitForNewPlayers',   '/api/game/waitForNewPlayers')
     config.add_route('getGameBoard',        '/api/game/getGameBoard')
+    config.add_route('setSessionWithGame',  '/api/game/setSessionWithGame')
 
     config.add_route('buySettlement',       '/api/player/buySettlement')
     config.add_route('waitForTurn',         '/api/player/waitForTurn')


### PR DESCRIPTION
I have added sessions support outside of the game page by way of /api/game/setSessionsWithGame. It requires an "game_id" and also can take an optional "player_id". See api_docs for further details.

Unfortunately, while this makes testing in Postman *possible*, it is still cumbersome for testing. That is because there is no way to manage session cookies in postman except to just delete the session. This means that if you want to "switch" between sessions, you will have to delete the cookie in postman and call /api/game/setSessionsWithGame again to set the new session. This works, but it is a PITA. 